### PR TITLE
test: fuzz

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.17.x, 1.16.x]
+        go-version: [1.24.x, 1.23.x, 1.22.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build
         run: go build
@@ -25,3 +25,31 @@ jobs:
         run: |
           go test -v ./... 
           go test -v ./... -race
+
+  fuzz:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.24.x]
+        os: [ubuntu-latest]
+        target: [
+          FuzzProveVerifySecp256k1,
+          FuzzProveVerifyP256,
+          FuzzDecodeProofSecp256k1,
+          FuzzDecodeProofP256,
+          FuzzHashToCurveTryAndIncrementSecp256k1,
+          FuzzHashToCurveTryAndIncrementP256
+        ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Fuzz (60s)
+        run: |
+          go test -run=^$ -fuzz=^${{ matrix.target }}$ -fuzztime=60s ./...

--- a/fuzz_core_test.go
+++ b/fuzz_core_test.go
@@ -1,0 +1,93 @@
+package ecvrf
+
+import (
+	"crypto/elliptic"
+	"testing"
+)
+
+func FuzzDecodeProofSecp256k1(f *testing.F) {
+	f.Add([]byte{0x00})
+	f.Add([]byte{0x02, 0x01})
+
+	f.Fuzz(func(t *testing.T, pi []byte) {
+		// Retrieve core config from the preconfigured VRF
+		temp := Secp256k1Sha256Tai.(*vrf)
+		c := &core{Config: &temp.cfg}
+
+		// Ensure no panic occurs during decoding
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("DecodeProof panicked: %v", r)
+			}
+		}()
+
+		_, _, _, _ = c.DecodeProof(pi)
+	})
+}
+
+func FuzzDecodeProofP256(f *testing.F) {
+	f.Add([]byte{0x00})
+	f.Add([]byte{0x02, 0x01})
+
+	f.Fuzz(func(t *testing.T, pi []byte) {
+		temp := P256Sha256Tai.(*vrf)
+		c := &core{Config: &temp.cfg}
+
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("DecodeProof panicked: %v", r)
+			}
+		}()
+
+		_, _, _, _ = c.DecodeProof(pi)
+	})
+}
+
+func FuzzHashToCurveTryAndIncrementSecp256k1(f *testing.F) {
+	f.Add([]byte("Hello"), []byte{1})
+	f.Add([]byte{0x01, 0x02, 0x03}, []byte{0xFF})
+
+	f.Fuzz(func(t *testing.T, alpha []byte, skSeed []byte) {
+		sk := deriveSecp256k1Key(skSeed)
+		if sk == nil {
+			t.Skip()
+		}
+		temp := Secp256k1Sha256Tai.(*vrf)
+		c := &core{Config: &temp.cfg}
+		H, err := c.HashToCurveTryAndIncrement(&point{sk.PublicKey.X, sk.PublicKey.Y}, alpha)
+		if err != nil {
+			// No guarantee that a valid point is found for all inputs; just ensure no panic.
+			return
+		}
+		if !c.Curve.IsOnCurve(H.X, H.Y) {
+			t.Fatalf("returned point is not on curve")
+		}
+	})
+}
+
+func FuzzHashToCurveTryAndIncrementP256(f *testing.F) {
+	f.Add([]byte("Hello"), []byte{2})
+	f.Add([]byte{0x01, 0x02, 0x03}, []byte{0x01, 0x02})
+
+	f.Fuzz(func(t *testing.T, alpha []byte, skSeed []byte) {
+		if len(skSeed) == 0 {
+			t.Skip()
+		}
+		curve := elliptic.P256()
+		temp := P256Sha256Tai.(*vrf)
+		c := &core{Config: &temp.cfg}
+
+		sk := deriveP256Key(skSeed)
+		if sk == nil {
+			t.Skip()
+		}
+
+		H, err := c.HashToCurveTryAndIncrement(&point{sk.PublicKey.X, sk.PublicKey.Y}, alpha)
+		if err != nil {
+			return
+		}
+		if !curve.IsOnCurve(H.X, H.Y) {
+			t.Fatalf("returned point is not on curve")
+		}
+	})
+}

--- a/fuzz_core_test.go
+++ b/fuzz_core_test.go
@@ -1,7 +1,6 @@
 package ecvrf
 
 import (
-	"crypto/elliptic"
 	"testing"
 )
 
@@ -59,7 +58,7 @@ func FuzzHashToCurveTryAndIncrementSecp256k1(f *testing.F) {
 			// No guarantee that a valid point is found for all inputs; just ensure no panic.
 			return
 		}
-		if !c.Curve.IsOnCurve(H.X, H.Y) {
+		if c.Unmarshal(c.Marshal(H)) == nil {
 			t.Fatalf("returned point is not on curve")
 		}
 	})
@@ -73,7 +72,6 @@ func FuzzHashToCurveTryAndIncrementP256(f *testing.F) {
 		if len(skSeed) == 0 {
 			t.Skip()
 		}
-		curve := elliptic.P256()
 		temp := P256Sha256Tai.(*vrf)
 		c := &core{Config: &temp.cfg}
 
@@ -86,7 +84,7 @@ func FuzzHashToCurveTryAndIncrementP256(f *testing.F) {
 		if err != nil {
 			return
 		}
-		if !curve.IsOnCurve(H.X, H.Y) {
+		if c.Unmarshal(c.Marshal(H)) == nil {
 			t.Fatalf("returned point is not on curve")
 		}
 	})

--- a/fuzz_vrf_test.go
+++ b/fuzz_vrf_test.go
@@ -1,0 +1,126 @@
+package ecvrf
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"math/big"
+	"testing"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+// deriveSecp256k1Key deterministically maps arbitrary bytes to a valid secp256k1 private key.
+// d = (seed % (N-1)) + 1 to ensure 1 <= d < N
+func deriveSecp256k1Key(seed []byte) *ecdsa.PrivateKey {
+	if len(seed) == 0 {
+		return nil
+	}
+	curve := secp256k1.S256()
+	q := curve.Params().N
+	d := new(big.Int).SetBytes(seed)
+	d.Mod(d, new(big.Int).Sub(q, big.NewInt(1)))
+	d.Add(d, big.NewInt(1))
+	sk := secp256k1.PrivKeyFromBytes(d.Bytes())
+	return sk.ToECDSA()
+}
+
+// deriveP256Key deterministically maps arbitrary bytes to a valid P-256 private key.
+// d = (seed % (N-1)) + 1 to ensure 1 <= d < N
+func deriveP256Key(seed []byte) *ecdsa.PrivateKey {
+	if len(seed) == 0 {
+		return nil
+	}
+	curve := elliptic.P256()
+	q := curve.Params().N
+	d := new(big.Int).SetBytes(seed)
+	d.Mod(d, new(big.Int).Sub(q, big.NewInt(1)))
+	d.Add(d, big.NewInt(1))
+	x, y := curve.ScalarBaseMult(d.Bytes())
+	return &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{Curve: curve, X: x, Y: y},
+		D:         d,
+	}
+}
+
+func FuzzProveVerifySecp256k1(f *testing.F) {
+	// Seed with a simple example
+	f.Add([]byte("Hello VeChain"), []byte{1})
+	f.Add([]byte{0x00, 0x01, 0x02}, []byte{0xFF, 0x00, 0xAA})
+
+	f.Fuzz(func(t *testing.T, alpha []byte, skSeed []byte) {
+		sk := deriveSecp256k1Key(skSeed)
+		if sk == nil {
+			t.Skip()
+		}
+
+		vrf := Secp256k1Sha256Tai
+
+		beta1, pi, err := vrf.Prove(sk, alpha)
+		if err != nil {
+			// Not all inputs must be valid; just ensure no panic and continue.
+			return
+		}
+
+		beta2, err := vrf.Verify(&sk.PublicKey, alpha, pi)
+		if err != nil {
+			t.Fatalf("Verify failed for self-produced proof: %v", err)
+		}
+		if !bytes.Equal(beta1, beta2) {
+			t.Fatalf("beta mismatch: got %x vs %x", beta1, beta2)
+		}
+
+		// Negative check: mutate the proof slightly and expect verification to fail
+		if len(pi) > 0 {
+			mutated := make([]byte, len(pi))
+			copy(mutated, pi)
+			mutated[0] ^= 0x01
+			if !bytes.Equal(mutated, pi) {
+				if _, err := vrf.Verify(&sk.PublicKey, alpha, mutated); err == nil {
+					t.Fatalf("mutated proof unexpectedly verified")
+				}
+			}
+		}
+	})
+}
+
+func FuzzProveVerifyP256(f *testing.F) {
+	// Seed with a simple example
+	f.Add([]byte("Hello VeChain"), []byte{2})
+	f.Add([]byte{0x10, 0x20}, []byte{0x01, 0x02, 0x03})
+
+	f.Fuzz(func(t *testing.T, alpha []byte, skSeed []byte) {
+		sk := deriveP256Key(skSeed)
+		if sk == nil {
+			t.Skip()
+		}
+
+		vrf := P256Sha256Tai
+
+		beta1, pi, err := vrf.Prove(sk, alpha)
+		if err != nil {
+			// Not all inputs must be valid; just ensure no panic and continue.
+			return
+		}
+
+		beta2, err := vrf.Verify(&sk.PublicKey, alpha, pi)
+		if err != nil {
+			t.Fatalf("Verify failed for self-produced proof: %v", err)
+		}
+		if !bytes.Equal(beta1, beta2) {
+			t.Fatalf("beta mismatch: got %x vs %x", beta1, beta2)
+		}
+
+		// Negative check: mutate the proof slightly and expect verification to fail
+		if len(pi) > 0 {
+			mutated := make([]byte, len(pi))
+			copy(mutated, pi)
+			mutated[0] ^= 0x01
+			if !bytes.Equal(mutated, pi) {
+				if _, err := vrf.Verify(&sk.PublicKey, alpha, mutated); err == nil {
+					t.Fatalf("mutated proof unexpectedly verified")
+				}
+			}
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/vechain/go-ecvrf
 
-go 1.16
+go 1.24.2
 
-require github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
+require github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,2 @@
-github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=


### PR DESCRIPTION
Fuzz tests for:
1. VRF ("external" api, `Verify`, `Prove`)
2. Core functions (`DecodeProof`, `HashToCurve`)

Updated go version so we can use the internal fuzz testing framework

Added fuzz tests to the CI

Closes https://github.com/vechain/protocol-board-repo/issues/897