### PR TITLE
chore: validate that public key is on curve

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           FuzzDecodeProofSecp256k1,
           FuzzDecodeProofP256,
           FuzzHashToCurveTryAndIncrementSecp256k1,
-          FuzzHashToCurveTryAndIncrementP256
+          FuzzHashToCurveTryAndIncrementP256,
           FuzzProveVerifyRandomKeysSecp256k1,
           FuzzProveVerifyRandomKeysP256,
         ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
           FuzzDecodeProofP256,
           FuzzHashToCurveTryAndIncrementSecp256k1,
           FuzzHashToCurveTryAndIncrementP256
+          FuzzProveVerifyRandomKeysSecp256k1,
+          FuzzProveVerifyRandomKeysP256,
         ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	@go test ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,16 @@
-.PHONY: test
+FUZZTIME=1m
+
+.PHONY: fuzz test
+
+fuzz:
+	@go test -fuzz=FuzzProveVerifySecp256k1 -fuzztime=$(FUZZTIME)
+	@go test -fuzz=FuzzProveVerifyP256 -fuzztime=$(FUZZTIME)
+	@go test -fuzz=FuzzDecodeProofSecp256k1 -fuzztime=$(FUZZTIME)
+	@go test -fuzz=FuzzDecodeProofP256 -fuzztime=$(FUZZTIME)
+	@go test -fuzz=FuzzHashToCurveTryAndIncrementSecp256k1 -fuzztime=$(FUZZTIME)
+	@go test -fuzz=FuzzHashToCurveTryAndIncrementP256 -fuzztime=$(FUZZTIME)
+	@go test -fuzz=FuzzProveVerifyRandomKeysSecp256k1 -fuzztime=$(FUZZTIME)
+	@go test -fuzz=FuzzProveVerifyRandomKeysP256 -fuzztime=$(FUZZTIME)
 
 test:
 	@go test ./...

--- a/fuzz_vrf_test.go
+++ b/fuzz_vrf_test.go
@@ -124,3 +124,243 @@ func FuzzProveVerifyP256(f *testing.F) {
 		}
 	})
 }
+
+// makeSecp256k1Key directly constructs a private key from raw bytes without derivation.
+// It may return a private key with public key that is NOT on curve (for fuzzing purposes).
+func makeSecp256k1Key(data []byte) *ecdsa.PrivateKey {
+	if len(data) == 0 {
+		return nil
+	}
+	curve := secp256k1.S256()
+	q := curve.Params().N
+
+	// If data is at least 96 bytes (32 for D + 32 for X + 32 for Y), try to construct
+	// private key with potentially invalid public key coordinates
+	if len(data) >= 96 {
+		// First 32 bytes as private key scalar D
+		privKeyBytes := make([]byte, 32)
+		copy(privKeyBytes, data[:32])
+		d := new(big.Int).SetBytes(privKeyBytes)
+		if d.Sign() == 0 || d.Cmp(q) >= 0 {
+			d.Mod(d, new(big.Int).Sub(q, big.NewInt(1)))
+			d.Add(d, big.NewInt(1))
+		}
+
+		// Next 32 bytes as X coordinate (may not be on curve)
+		x := new(big.Int).SetBytes(data[32:64])
+		// Next 32 bytes as Y coordinate (may not be on curve)
+		y := new(big.Int).SetBytes(data[64:96])
+
+		// Don't check IsOnCurve - allow testing invalid points
+		return &ecdsa.PrivateKey{
+			PublicKey: ecdsa.PublicKey{Curve: curve, X: x, Y: y},
+			D:         d,
+		}
+	}
+
+	// Use data directly as private key scalar (standard case, always on curve)
+	privKeyBytes := make([]byte, 32)
+	if len(data) <= 32 {
+		copy(privKeyBytes[32-len(data):], data)
+	} else {
+		copy(privKeyBytes, data[:32])
+	}
+
+	d := new(big.Int).SetBytes(privKeyBytes)
+	if d.Sign() == 0 || d.Cmp(q) >= 0 {
+		d.Mod(d, new(big.Int).Sub(q, big.NewInt(1)))
+		d.Add(d, big.NewInt(1))
+	}
+
+	sk := secp256k1.PrivKeyFromBytes(d.Bytes())
+	return sk.ToECDSA()
+}
+
+// makeP256Key directly constructs a private key from raw bytes without derivation.
+// It may return a private key with public key that is NOT on curve (for fuzzing purposes).
+func makeP256Key(data []byte) *ecdsa.PrivateKey {
+	if len(data) == 0 {
+		return nil
+	}
+	curve := elliptic.P256()
+	q := curve.Params().N
+
+	// If data is at least 96 bytes (32 for D + 32 for X + 32 for Y), try to construct
+	// private key with potentially invalid public key coordinates
+	if len(data) >= 96 {
+		// First 32 bytes as private key scalar D
+		d := new(big.Int).SetBytes(data[:32])
+		if d.Sign() == 0 || d.Cmp(q) >= 0 {
+			d.Mod(d, new(big.Int).Sub(q, big.NewInt(1)))
+			d.Add(d, big.NewInt(1))
+		}
+
+		// Next 32 bytes as X coordinate (may not be on curve)
+		x := new(big.Int).SetBytes(data[32:64])
+		// Next 32 bytes as Y coordinate (may not be on curve)
+		y := new(big.Int).SetBytes(data[64:96])
+
+		// Don't check IsOnCurve - allow testing invalid points
+		return &ecdsa.PrivateKey{
+			PublicKey: ecdsa.PublicKey{Curve: curve, X: x, Y: y},
+			D:         d,
+		}
+	}
+
+	// Standard case: use data as private key scalar (always generates valid on-curve point)
+	d := new(big.Int).SetBytes(data)
+	if d.Sign() == 0 || d.Cmp(q) >= 0 {
+		d.Mod(d, new(big.Int).Sub(q, big.NewInt(1)))
+		d.Add(d, big.NewInt(1))
+	}
+
+	x, y := curve.ScalarBaseMult(d.Bytes())
+	return &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{Curve: curve, X: x, Y: y},
+		D:         d,
+	}
+}
+
+// makeSecp256k1PublicKey directly constructs a public key from raw bytes.
+// It may return a public key that is NOT on curve (for fuzzing purposes).
+func makeSecp256k1PublicKey(data []byte) *ecdsa.PublicKey {
+	if len(data) == 0 {
+		return nil
+	}
+
+	// Try to parse as public key (compressed or uncompressed)
+	pubKey, err := secp256k1.ParsePubKey(data)
+	if err == nil {
+		return pubKey.ToECDSA()
+	}
+
+	// If data is at least 64 bytes, try to construct from X and Y directly
+	// This allows fuzzer to generate random X, Y coordinates that may not be on curve
+	if len(data) >= 64 {
+		curve := secp256k1.S256()
+		x := new(big.Int).SetBytes(data[:32])
+		y := new(big.Int).SetBytes(data[32:64])
+		// Don't check IsOnCurve - allow testing invalid points
+		return &ecdsa.PublicKey{Curve: curve, X: x, Y: y}
+	}
+
+	// If parsing fails, construct from private key (this will always be on curve)
+	sk := makeSecp256k1Key(data)
+	if sk != nil {
+		return &sk.PublicKey
+	}
+	return nil
+}
+
+// makeP256PublicKey directly constructs a public key from raw bytes.
+// It may return a public key that is NOT on curve (for fuzzing purposes).
+func makeP256PublicKey(data []byte) *ecdsa.PublicKey {
+	if len(data) == 0 {
+		return nil
+	}
+
+	curve := elliptic.P256()
+
+	// Try uncompressed format (0x04 || X || Y)
+	if len(data) >= 65 && data[0] == 0x04 {
+		x := new(big.Int).SetBytes(data[1:33])
+		y := new(big.Int).SetBytes(data[33:65])
+		// Don't check IsOnCurve here - allow fuzzer to test invalid points
+		return &ecdsa.PublicKey{Curve: curve, X: x, Y: y}
+	}
+
+	// Try compressed format
+	if len(data) >= 33 && (data[0] == 0x02 || data[0] == 0x03) {
+		x, y := elliptic.UnmarshalCompressed(curve, data)
+		if x != nil && y != nil {
+			return &ecdsa.PublicKey{Curve: curve, X: x, Y: y}
+		}
+	}
+
+	// If data is at least 64 bytes, try to construct from X and Y directly (without format byte)
+	// This allows fuzzer to generate random X, Y coordinates that may not be on curve
+	if len(data) >= 64 {
+		x := new(big.Int).SetBytes(data[:32])
+		y := new(big.Int).SetBytes(data[32:64])
+		// Don't check IsOnCurve - allow testing invalid points
+		return &ecdsa.PublicKey{Curve: curve, X: x, Y: y}
+	}
+
+	// If parsing fails, construct from private key (this will always be on curve)
+	sk := makeP256Key(data)
+	if sk != nil {
+		return &sk.PublicKey
+	}
+
+	return nil
+}
+
+// FuzzProveVerifyRandomKeysP256 fuzzes Prove and Verify with random private key and public key inputs for P256 curve.
+func FuzzProveVerifyRandomKeysP256(f *testing.F) {
+	f.Add([]byte{0x01, 0x02}, []byte{0x03, 0x04}, []byte("alpha"))
+
+	sk := makeP256Key([]byte("test_seed_123456789012345678901234567890"))
+	if sk != nil {
+		pubKeyBytes := elliptic.MarshalCompressed(elliptic.P256(), sk.X, sk.Y)
+		f.Add(sk.D.Bytes(), pubKeyBytes, []byte("test"))
+	}
+
+	f.Fuzz(func(t *testing.T, skBytes []byte, pkBytes []byte, alpha []byte) {
+		sk := makeP256Key(skBytes)
+		if sk == nil {
+			t.Skip()
+		}
+
+		vrf := P256Sha256Tai
+
+		beta1, pi, err := vrf.Prove(sk, alpha)
+		if err != nil {
+			return
+		}
+
+		beta2, err := vrf.Verify(&sk.PublicKey, alpha, pi)
+		if err != nil {
+			t.Fatalf("P256 Verify failed: %v", err)
+		}
+		if !bytes.Equal(beta1, beta2) {
+			t.Fatalf("P256 beta mismatch: got %x vs %x", beta1, beta2)
+		}
+	})
+}
+
+// FuzzProveVerifyRandomKeysSecp256k1 fuzzes Prove and Verify with random private key and public key inputs for secp256k1 curve.
+func FuzzProveVerifyRandomKeysSecp256k1(f *testing.F) {
+	f.Add([]byte{0x01, 0x02}, []byte{0x03, 0x04}, []byte("alpha"))
+
+	sk := makeSecp256k1Key([]byte("test_seed_123456789012345678901234567890"))
+	if sk != nil {
+		var x, y secp256k1.FieldVal
+		x.SetByteSlice(sk.X.Bytes())
+		y.SetByteSlice(sk.Y.Bytes())
+		pubKey := secp256k1.NewPublicKey(&x, &y)
+		pubKeyBytes := pubKey.SerializeCompressed()
+		f.Add(sk.D.Bytes(), pubKeyBytes, []byte("test"))
+	}
+
+	f.Fuzz(func(t *testing.T, skBytes []byte, pkBytes []byte, alpha []byte) {
+		sk := makeSecp256k1Key(skBytes)
+		if sk == nil {
+			t.Skip()
+		}
+
+		vrf := Secp256k1Sha256Tai
+
+		beta1, pi, err := vrf.Prove(sk, alpha)
+		if err != nil {
+			return
+		}
+
+		beta2, err := vrf.Verify(&sk.PublicKey, alpha, pi)
+		if err != nil {
+			t.Fatalf("secp256k1 Verify failed: %v", err)
+		}
+		if !bytes.Equal(beta1, beta2) {
+			t.Fatalf("secp256k1 beta mismatch: got %x vs %x", beta1, beta2)
+		}
+	})
+}

--- a/vrf.go
+++ b/vrf.go
@@ -159,6 +159,11 @@ func (v *vrf) Verify(pk *ecdsa.PublicKey, alpha, pi []byte) (beta []byte, err er
 		return
 	}
 
+	if !v.cfg.Curve.IsOnCurve(pk.X, pk.Y) {
+		err = errors.New("public key is not on curve")
+		return
+	}
+
 	core := core{Config: &v.cfg}
 	// step 1: D = ECVRF_decode_proof(pi_string)
 	gamma, c, s, err := core.DecodeProof(pi)

--- a/vrf.go
+++ b/vrf.go
@@ -159,6 +159,11 @@ func (v *vrf) Verify(pk *ecdsa.PublicKey, alpha, pi []byte) (beta []byte, err er
 		return
 	}
 
+	if pk.Curve != v.cfg.Curve {
+		err = errors.New("public key curve does not match config curve")
+		return
+	}
+
 	if !v.cfg.Curve.IsOnCurve(pk.X, pk.Y) {
 		err = errors.New("public key is not on curve")
 		return

--- a/vrf.go
+++ b/vrf.go
@@ -103,6 +103,11 @@ func (v *vrf) Prove(sk *ecdsa.PrivateKey, alpha []byte) (beta, pi []byte, err er
 		return
 	}
 
+	err = v.validatePublicKey(&sk.PublicKey)
+	if err != nil {
+		return
+	}
+
 	var (
 		core = core{Config: &v.cfg}
 		q    = core.Q()
@@ -151,13 +156,8 @@ func (v *vrf) Prove(sk *ecdsa.PrivateKey, alpha []byte) (beta, pi []byte, err er
 	return
 }
 
-// validatePublicKey validates the public key to prevent nil pointer dereference and ensure it is on the correct curve.
+// validatePublicKey validates the public key's curve and point on the curve.
 func (v *vrf) validatePublicKey(pk *ecdsa.PublicKey) error {
-	// Validate input parameters to prevent nil pointer dereference
-	if pk == nil || pk.X == nil || pk.Y == nil {
-		return errors.New("public key and its fields (X, Y) cannot be nil")
-	}
-
 	if pk.Curve != v.cfg.Curve {
 		return errors.New("public key curve does not match config curve")
 	}
@@ -171,6 +171,11 @@ func (v *vrf) validatePublicKey(pk *ecdsa.PublicKey) error {
 
 // Verify checks the correctness of proof following [draft-irtf-cfrg-vrf-06 section 5.3](https://tools.ietf.org/id/draft-irtf-cfrg-vrf-06.html#rfc.section.5.3).
 func (v *vrf) Verify(pk *ecdsa.PublicKey, alpha, pi []byte) (beta []byte, err error) {
+	// Validate input parameters to prevent nil pointer dereference
+	if pk == nil || pk.X == nil || pk.Y == nil {
+		err = errors.New("public key and its fields (X, Y) cannot be nil")
+		return
+	}
 	err = v.validatePublicKey(pk)
 	if err != nil {
 		return

--- a/vrf_test.go
+++ b/vrf_test.go
@@ -615,3 +615,36 @@ func TestVerifyPublicKeyOnCurveValidation(t *testing.T) {
 		}
 	})
 }
+
+func TestVerifyPublicKeyCurveMismatch(t *testing.T) {
+	t.Run("secp256k1 vrf with p256 public key", func(t *testing.T) {
+		vrf := Secp256k1Sha256Tai
+
+		curve := elliptic.P256()
+		sk, _ := ecdsa.GenerateKey(curve, rand.New(rand.NewSource(7)))
+		pk := &sk.PublicKey
+
+		_, err := vrf.Verify(pk, []byte("test"), []byte("fake proof"))
+		if err == nil {
+			t.Fatal("expected error for curve mismatch, got nil")
+		}
+		if err.Error() != "public key curve does not match config curve" {
+			t.Fatalf("expected 'public key curve does not match config curve', got %q", err.Error())
+		}
+	})
+
+	t.Run("p256 vrf with secp256k1 public key", func(t *testing.T) {
+		vrf := P256Sha256Tai
+
+		sk, _ := secp256k1.GeneratePrivateKey()
+		pk := &sk.ToECDSA().PublicKey
+
+		_, err := vrf.Verify(pk, []byte("test"), []byte("fake proof"))
+		if err == nil {
+			t.Fatal("expected error for curve mismatch, got nil")
+		}
+		if err.Error() != "public key curve does not match config curve" {
+			t.Fatalf("expected 'public key curve does not match config curve', got %q", err.Error())
+		}
+	})
+}


### PR DESCRIPTION
Extra validation to check that the points representing the public key are on the elliptic curve.